### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Then add this line of code after the container was built.
 
 ```php
 // Call the HookCallbackProviderInterface to register hooks
-$container->get(\Kaiseki\WordPress\Hook\HookCallbackProviderInterface::class)->registerCallbacks();
+$container->get(\Kaiseki\WordPress\Hook\HookCallbackProviderRegistry::class)->registerCallbacks();
 ```
 
 ### Config Providers

--- a/tests/unit/ContainerBuilderTest.php
+++ b/tests/unit/ContainerBuilderTest.php
@@ -73,10 +73,10 @@ class ContainerBuilderTest extends TestCase
     public function instanceIsClonedCases(): iterable
     {
         yield 'withConfigFolder' => [
-            fn(ContainerBuilder $builder): ContainerBuilder => $builder->withConfigFolder('/')
+            fn(ContainerBuilder $builder): ContainerBuilder => $builder->withConfigFolder('/'),
         ];
         yield 'withCachedConfigFile' => [
-            fn(ContainerBuilder $builder): ContainerBuilder => $builder->withCachedConfigFile('cached-config.php')
+            fn(ContainerBuilder $builder): ContainerBuilder => $builder->withCachedConfigFile('cached-config.php'),
         ];
     }
 }


### PR DESCRIPTION
Fix incorrect class reference when initializing `kaiseki-wp-hook`