### PR TITLE
CHANGELOG: release as 2.0.0; add retrospective 1.0.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,24 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.0.0 - 2026-05-29
-
-First tagged release.
-
-### Added
-
-- `Kaiseki\ContainerBuilder\ContainerBuilder` — builds a PSR-11 container from config providers using
-  laminas-servicemanager and laminas-di, with `withConfigFolder()` and `withCachedConfigFile()`.
+## 2.0.0 - 2026-05-30
 
 ### Changed
 
-- PHP requirement is `^8.2` (PHP 8.4 is the primary target).
+- **BC:** raised the PHP requirement to `^8.2` (was `^8.1`). PHP 8.4 is the primary target.
 - Modernized the dev toolchain (PHPStan 2, PHPUnit 11, composer-require-checker 4) and depend on
   `kaiseki/php-coding-standard: ^1.0` with the shared PHPStan config; CI runs via the reusable
   workflow in `kaisekidev/.github`.
 - PHPUnit 11 test updates: static data provider + `#[DataProvider]` attribute.
 - Imported laminas' `ServiceManagerConfiguration` type and narrowed the merged DI config at runtime
   so `ContainerBuilder` passes PHPStan level max without suppression.
+
+## 1.0.0 - 2022-02-06
+
+Initial public release.
+
+### Added
+
+- `Kaiseki\ContainerBuilder\ContainerBuilder` — builds a PSR-11 container from config providers
+  using laminas-servicemanager and laminas-di, with `withConfigFolder()` and
+  `withCachedConfigFile()` for layered configuration and config caching.


### PR DESCRIPTION
## Summary
A `1.0.0` tag already exists on this repo from **2022-02-06** (initial release with the original `ContainerBuilder`), so the migration release that just landed via #2 should be **`2.0.0`**, not `1.0.0`.

- Re-label the new release section `## 1.0.0 - 2026-05-29` → `## 2.0.0 - 2026-05-30`.
- Drop the incorrect "First tagged release" line.
- Mark the PHP floor bump (`^8.1` → `^8.2`) explicitly as **BC** under Changed (this is what makes it major under SemVer).
- Append a retrospective `## 1.0.0 - 2022-02-06` section describing what shipped originally.

After this merges, I'll tag `2.0.0` on the resulting master.

## Test plan
- [ ] CHANGELOG entries in reverse chronological order, both with content.