### PR TITLE
ci(docs): harden notify-site (fork guard, Content-Type, retry)

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,9 +1,9 @@
 # Add this workflow to each kaiseki package repository as
 # `.github/workflows/notify-site.yml`.
 #
-# On every push to the default branch (and on published releases) it tells the
-# kaiseki-site repo to rebuild, so the documentation site always reflects the
-# latest README / docs.
+# On every push to the repo's default branch (master or main) and on published
+# releases, it tells the kaiseki-site repo to rebuild, so the documentation site
+# always reflects the latest README / docs.
 #
 # ── HOW IT AUTHENTICATES ────────────────────────────────────────────────────
 # It mints a short-lived token from the org's `kaiseki-doc-bot` GitHub App,
@@ -12,6 +12,9 @@
 # the only stored credential is the org-level App private key (APP_PRIVATE_KEY),
 # already shared with every repo for the changelog flow. App installation tokens
 # (unlike the Actions GITHUB_TOKEN) are allowed to trigger the downstream build.
+#
+# The job is guarded to the kaisekidev org, so forks — which can't read the org
+# secrets — don't run it and fail.
 #
 # Prerequisites (one-time, org-wide — already in place):
 #   - `kaiseki-doc-bot` App installed on all repos incl. kaiseki-site (contents: write).
@@ -31,6 +34,9 @@ permissions:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    # Skip on forks: the org secrets aren't available there, so the dispatch
+    # can't authenticate and the run would just fail.
+    if: ${{ github.repository_owner == 'kaisekidev' }}
     steps:
       - name: Mint a token scoped to kaiseki-site
         id: app-token
@@ -43,9 +49,10 @@ jobs:
 
       - name: Dispatch rebuild of kaiseki-site
         run: |
-          curl -fsSL -X POST \
+          curl -fsSL --retry 3 --retry-all-errors -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Content-Type: application/json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/kaisekidev/kaiseki-site/dispatches \
             -d '{"event_type":"package-updated","client_payload":{"repo":"${{ github.repository }}","sha":"${{ github.sha }}"}}'


### PR DESCRIPTION
## Summary

Hardens the `notify-site.yml` rolled out across the org, addressing review
feedback. Behaviour is unchanged on `kaisekidev` repos (the dispatch already
works); these are robustness/correctness improvements.

## Changes

- **Fork guard** — `if: github.repository_owner == 'kaisekidev'` so forks (no
  access to the org App secrets) don't run the job and fail.
- **`Content-Type: application/json`** header on the dispatch request.
- **`--retry 3 --retry-all-errors`** on curl for transient API/network blips.
- Comment clarified: triggers on the default branch (`master`/`main`).

## Validation

- Workflow-only change; no library code touched. Shared `checks / build` gates the merge.